### PR TITLE
Peg theme at Typedoc v0.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+
+| :zap:   This theme is pegged at Typedoc v0.23 due to [breaking API changes](https://github.com/TypeStrong/typedoc/releases/tag/v0.24.0) in v0.24 |
+|-----------------------------------------|
+
 # typedoc-theme-yaf
 
 A theme that optimises deep project exploration, graphical clarity and a fluid end user experience.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "typedoc-theme-yaf",
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"description": "A fresh, opinionated and standalone front-end documentation application consuming Typedoc generated data.",
 	"keywords": [
 		"typedoc",

--- a/src/frontend/index.ts
+++ b/src/frontend/index.ts
@@ -28,7 +28,7 @@ export * as handlers from './handlers/index.js';
  * This library replicates (in principle) the semantics of the default TypeDoc theme backend templating into the frontend scope.
  * It tries to be semantically as close as possible to the default, but does depart in some details and sometimes takes it own tangent...
  *
- * All data to feed the frontend component logic is {@link backend!YafTheme#saveYafThemeAssets | generated at document build time} as .json fragments
+ * All data to feed the frontend component logic is generated at document build time as .json fragments
  * (instead of the default theme HTML pages) and loaded into the browser as required.
  */
 export * as webComponents from './webComponents/index.js';


### PR DESCRIPTION
This theme is pegged at Typedoc v0.23 due to [breaking API changes](https://github.com/TypeStrong/typedoc/releases/tag/v0.24.0) in v0.24